### PR TITLE
Remove t3docs/site-package

### DIFF
--- a/Initialisation/Site/main/config.yaml
+++ b/Initialisation/Site/main/config.yaml
@@ -1,7 +1,6 @@
 base: '/'
 dependencies:
   - typo3/form
-  - t3docs/site-package
 languages:
   -
     title: English


### PR DESCRIPTION
In order to let the tutorial user add it.
And it will avoid warning message with missing site set

Releases : main, 13.4